### PR TITLE
feat: export FRG brand colors for external use

### DIFF
--- a/list.go
+++ b/list.go
@@ -126,7 +126,7 @@ func NewInfoListModel(input NewInfoListModelInput) (InfoListModel, error) {
 	vp := viewport.New(defaultWidth, listHeight-2)
 	vp.Style = lipgloss.NewStyle().
 		BorderStyle(lipgloss.NormalBorder()).
-		BorderForeground(lipgloss.Color(frgMagenta)).
+		BorderForeground(lipgloss.Color(FrgMagenta)).
 		PaddingRight(2)
 
 	renderer, err := glamour.NewTermRenderer(

--- a/theme.go
+++ b/theme.go
@@ -12,10 +12,10 @@ func FormTheme() *huh.Theme {
 	// Define adaptive colors based on the palette. Where possible a slightly
 	// brighter variant is used in dark mode to improve contrast.
 	var (
-		accent = lipgloss.AdaptiveColor{Light: frgMagenta, Dark: frgLime}
-		white  = lipgloss.AdaptiveColor{Light: frgDarkGray, Dark: frgLightGray}
-		gray   = lipgloss.AdaptiveColor{Light: frgDarkGray, Dark: frgGray}
-		mint   = lipgloss.AdaptiveColor{Light: frgMint, Dark: frgMint}
+		accent = lipgloss.AdaptiveColor{Light: FrgMagenta, Dark: FrgLime}
+		white  = lipgloss.AdaptiveColor{Light: FrgDarkGray, Dark: FrgLightGray}
+		gray   = lipgloss.AdaptiveColor{Light: FrgDarkGray, Dark: FrgGray}
+		mint   = lipgloss.AdaptiveColor{Light: FrgMint, Dark: FrgMint}
 		red    = lipgloss.Color("#FF0000")
 	)
 
@@ -29,7 +29,7 @@ func FormTheme() *huh.Theme {
 	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(accent)
 	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(accent)
 	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(accent)
-	t.Focused.FocusedButton = t.Focused.FocusedButton.Foreground(lipgloss.Color(frgBlack)).Background(accent).Bold(true)
+	t.Focused.FocusedButton = t.Focused.FocusedButton.Foreground(lipgloss.Color(FrgBlack)).Background(accent).Bold(true)
 	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(accent)
 	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(accent)
 	t.Focused.ErrorMessage = t.Focused.ErrorMessage.Foreground(red)

--- a/tui.go
+++ b/tui.go
@@ -2,19 +2,20 @@ package tui
 
 import "github.com/charmbracelet/lipgloss"
 
+// FRG brand colors for consistent theming across applications
 const (
-	frgLime      = "#93C30B"
-	frgMagenta   = "#BD368D"
-	frgForest    = "#004610"
-	frgMint      = "#DBEAE5"
-	frgMaroon    = "#4B0325"
-	frgBlue      = "#244A66"
-	frgLightGray = "#F5F5F5"
-	frgGray      = "#A6A6A6"
-	frgDarkGray  = "#4B4B4B"
-	frgWhite     = "#FFFFFF"
-	frgBlack     = "#000000"
+	FrgLime      = "#93C30B"
+	FrgMagenta   = "#BD368D"
+	FrgForest    = "#004610"
+	FrgMint      = "#DBEAE5"
+	FrgMaroon    = "#4B0325"
+	FrgBlue      = "#244A66"
+	FrgLightGray = "#F5F5F5"
+	FrgGray      = "#A6A6A6"
+	FrgDarkGray  = "#4B4B4B"
+	FrgWhite     = "#FFFFFF"
+	FrgBlack     = "#000000"
 )
 
 var DefaultStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: frgMagenta, Dark: frgLime})
+	Foreground(lipgloss.AdaptiveColor{Light: FrgMagenta, Dark: FrgLime})


### PR DESCRIPTION
## Summary
- Export all FRG color constants by capitalizing them
- Update internal references to use exported constants
- Add documentation comment for color constants

## Motivation
The VOR Stream codebase needs to use the FRG brand colors for the new Consul dashboard feature. Currently, these colors are not exported from the tui package, requiring duplication of the color constants.

This PR exports the colors so they can be used by other packages while maintaining consistency across the FRG ecosystem.

## Changes
- Changed all color constants from lowercase to uppercase (e.g., `frgLime` → `FrgLime`)
- Updated all internal references in `tui.go`, `theme.go`, and `list.go`
- Added a documentation comment for the color constants

## Test plan
- [x] Run `go test ./...` - passes (no test files)
- [x] Verify code compiles without errors
- [x] Test in VOR Stream to ensure colors can be imported

🤖 Generated with [Claude Code](https://claude.ai/code)